### PR TITLE
fix: webApp built-in buttons compatibility

### DIFF
--- a/lib/keyboard.js
+++ b/lib/keyboard.js
@@ -25,7 +25,7 @@ const formatInlineButtons = (buttons) => {
 const formatBuiltInButtons = (buttons) => {
     return buttons.map(row => row.map(button => {
         if (typeof button === 'object') {
-            if (button.request_contact || button.request_location) {
+            if (button.request_contact || button.request_location || button.web_app) {
                 return button
             }
 


### PR DESCRIPTION
web app buttons doesn't work with built-in buttons implementation (using .reply())